### PR TITLE
Made CORS Origins Configurable via Environment (Closes #6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 VITE_SUPABASE_URL=your-supabase-url
 VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
 
+# Backend CORS Configuration (comma-separated list of allowed origins)
+# For production, replace with your actual domain(s)
+CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173
+
 # Note: NVIDIA API key should ONLY be set in Supabase Edge Function secrets
 # DO NOT add NVIDIA_API_KEY here - it will be exposed in the browser!
 # 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,5 +14,7 @@ DATABASE_URL=sqlite:///./flexiroaster.db
 # Logging
 LOG_LEVEL=INFO
 
-# CORS Origins (comma-separated)
+# CORS Origins (comma-separated list of allowed origins)
+# Development default: http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173
+# Production example: https://yourdomain.com,https://app.yourdomain.com
 CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173

--- a/backend/config.py
+++ b/backend/config.py
@@ -2,7 +2,8 @@
 Configuration settings for FlexiRoaster backend.
 """
 from pydantic_settings import BaseSettings
-from typing import Optional
+from pydantic import field_validator
+from typing import List, Optional, Union
 
 
 class Settings(BaseSettings):
@@ -15,7 +16,15 @@ class Settings(BaseSettings):
     
     # API
     API_PREFIX: str = "/api"
-    CORS_ORIGINS: list = ["http://localhost:3000", "http://localhost:5173", "http://127.0.0.1:5173"]
+    CORS_ORIGINS: Union[str, List[str]] = "http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173"
+
+    @field_validator("CORS_ORIGINS", mode="before")
+    @classmethod
+    def parse_cors_origins(cls, v):
+        """Parse CORS_ORIGINS from a comma-separated string or return list as-is."""
+        if isinstance(v, str):
+            return [origin.strip() for origin in v.split(",") if origin.strip()]
+        return v
     
     # Database
     DATABASE_URL: str = "sqlite:///./flexiroaster.db"
@@ -30,6 +39,7 @@ class Settings(BaseSettings):
     class Config:
         env_file = ".env"
         case_sensitive = True
+        extra = "ignore"
 
 
 # Global settings instance


### PR DESCRIPTION
Description
Externalize the CORS origins configuration to allow overriding via environment variables, removing the need for code changes when deploying to staging or production environments with different domains.

Changes Made

backend/config.py
Changed CORS_ORIGINS type from a hardcoded list to Union[str, List[str]] with a comma-separated string default
Added @field_validator (
                   parse_cors_origins
) to parse comma-separated strings into a list at startup

Added extra = "ignore" to the Config class to prevent errors from unrelated env vars
backend/.env.example-Added documented CORS_ORIGINS entry with dev defaults and a production example
.env.example-Added CORS_ORIGINS entry for project-level reference